### PR TITLE
remote assistance switch

### DIFF
--- a/bin/webservice/control_functions.py
+++ b/bin/webservice/control_functions.py
@@ -46,10 +46,28 @@ def run_gps_test():
     status = process.wait()
     message = process.stdout.read().decode('utf-8')
     messages = message.split('\n')
-    if status == '0':
+    if status == 0:
         return True, messages
     else:
         return False, messages
+
+def set_shellhub_access(access='always'):
+    """Update the shellhub docker status and restart configuration
+    param str access: set to always [default], session [until next reboot or failure], or disable'
+    """
+    if access == 'always':
+        status1 = os.system("/usr/bin/sudo docker update --restart on-failure shellhub")
+        status2 = os.system("/usr/bin/sudo docker start shellhub")
+    elif access == 'session':
+        status1 = os.system(f"/usr/bin/sudo docker start shellhub")
+        status2 = 0
+    elif access == 'disable':
+        status1 = os.system(f"/usr/bin/sudo docker update --restart no shellhub")
+        status2 = os.system(f"/usr/bin/sudo docker stop shellhub")
+    if (status1 == 0) and (status2 ==0):
+        return True, ["Remote assistance access updated"]
+    else:
+        return False, ["Failed to update remote assistance access"]
 
 def run_export_test(force=False):
     "Show data upload status and optionally force bulk upload"
@@ -64,7 +82,7 @@ def run_export_test(force=False):
     message = process.stdout.read().decode('utf-8')
     print(message)
     messages = message.split('\n')
-    if status == '0':
+    if status == 0:
         return True, messages
     else:
         return False, messages

--- a/bin/webservice/flaskws.py
+++ b/bin/webservice/flaskws.py
@@ -26,7 +26,7 @@ import glob
 import threading
 import zipfile
 from log_functions import read_log, log2dict
-from control_functions import restart_service, stop_service, service_status, run_gps_test, run_export_test
+from control_functions import restart_service, stop_service, service_status, run_gps_test, run_export_test, set_shellhub_access
 from redis_functions import redis_init, redis_retrieve
 import camera_functions
 
@@ -354,6 +354,20 @@ def control():
     elif selection == 'gps_test':
         # run a so-rad test script.
         status, messages = run_gps_test()
+        return render_template('control.html', messages=messages, common=common)
+
+    # shellhub access
+    elif selection == 'shellhub_always':
+        # run a so-rad test script.
+        status, messages = set_shellhub_access(access='always')
+        return render_template('control.html', messages=messages, common=common)
+    elif selection == 'shellhub_session':
+        # run a so-rad test script.
+        status, messages = set_shellhub_access(access='session')
+        return render_template('control.html', messages=messages, common=common)
+    elif selection == 'shellhub_disable':
+        # run a so-rad test script.
+        status, messages = set_shellhub_access(access='disable')
         return render_template('control.html', messages=messages, common=common)
 
     elif selection == 'export_test':

--- a/bin/webservice/templates/control.html
+++ b/bin/webservice/templates/control.html
@@ -22,28 +22,41 @@
       {% endif %}
     </p>
     <p>
+    <b>Set access level for remote assistance:</b><br>
+       'always' allows remote assistance (default).<br>
+       'session' provides access for the current session (until system restart).<br>
+       'disable' removes access until is is granted again.<br>
+       <input type = "submit" value = "always" name="shellhub_always"/>
+       <input type = "submit" value = "session" name="shellhub_session"/>
+       <input type = "submit" value = "disable" name="shellhub_disable"/>
+    </p>
+    <p>
+    <b>GPS test (requires So-Rad service to be stopped first):</b><br>
        <input type = "submit" value = "Test GPS" name="gps_test"/>
     </p>
     <p>
+    <b>Data export (requires So-Rad service to be stopped first):</b><br>
        <input type = "submit" value = "Data export status" name="export_test"/>
        <input type = "submit" value = "Upload data now" name="export_test_force"/>
     </p>
     <p>
+    <b>System reboot:</b><br>
        <input type = "submit" value = "Reboot" name="reboot"/>
        <input type = "submit" value = "Cancel Reboot" name="cancelreboot"/>
     </p>
     <p>
-       Warning: Once shut down, a power cycle is needed to restart the system! This cannot be done remotely.<br> 
+    <b>System shutdown:</b><br>
+    <b>Warning: Once shut down, a power cycle is needed to restart the system! This cannot be done remotely.</b><br> 
        <input type = "submit" value = "Shutdown" name="shutdown"/>
        <input type = "submit" value = "Cancel Shutdown" name="cancelreboot"/>
     </p>
   </p>
    </form>
   </div>
-
+<br>
   <div>
     <p>
-    Results:
+    <b>Results from the last command:</b>
     </p>
     {% for message in messages %}
       {{ message }}<br>


### PR DESCRIPTION
Adds switches in control menu to allow/disable remote assistance via shellhub, by starting/stopping and setting the automatic restart options of the shellhub container. Will raise errors if shellhub isn't installed. Will also require updating the command list for which the web service has elevated access rights. Test this.